### PR TITLE
broken markup on suitearch page

### DIFF
--- a/pybitweb/static/suitearch.htm
+++ b/pybitweb/static/suitearch.htm
@@ -84,10 +84,10 @@
                         <li>
                             <a href="formats.htm">Formats</a>
                         </li>
-                        <li
+                        <li>
                             <a href="suites.htm">Suites</a>
                         </li>
-                                                 <li class="active">>
+                                                 <li class="active">
                             <a href="suitearch.htm">Suite Arches</a>
                         </li>
                         <li class="nav-header">


### PR DESCRIPTION
one line fixed for a paste-o that broke the Suite link in the left pane.
